### PR TITLE
Handle status responses from jsonnet methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ JSON:
         stream: [ {response1}, {response2}, ... ]
     }
 
+A [gRPC status] can be returned in the `status` field:
+
+    function(input) {
+        status: {
+            code: 3,
+            message: 'Field "foo" failed validation: 0 < foo < 10',
+            details: [
+                {
+                    '@type': 'type.googleapis.com/google.protobuf.Duration',
+                    value: '15.2s',
+                },
+            ],
+        },
+    }
+
+If a result has a `status` field, it must not have a `response` or `stream`
+field.
+
 The response can reference fields of the input using regular jsonnet references.
 See the [testdata samples](./testdata).
 
@@ -81,6 +99,7 @@ To serve these jsonnet methods, run:
     jig serve --proto-set=service.pb --method-dir=dir
 
 
+[gRPC status]: https://www.grpc.io/docs/guides/error/
 [protojson]: https://developers.google.com/protocol-buffers/docs/proto3#json
 
 

--- a/testdata/echo.EchoService.Hello.jsonnet
+++ b/testdata/echo.EchoService.Hello.jsonnet
@@ -1,5 +1,18 @@
-function(input) {
-  response: {
-    response: 'Hello ' + input.request.message,
-  },
-}
+function(input)
+  local isBart = input.request.message == 'Bart';
+  {
+    [if !isBart then 'response']: {
+      response: 'Hello ' + input.request.message,
+    },
+
+    [if isBart then 'status']: {
+      code: 3,
+      message: 'eat my shorts',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.protobuf.Duration',
+          value: '101.212s',
+        },
+      ],
+    },
+  }


### PR DESCRIPTION
Handle the `status` field in a jsonnet method response as a Status
protobuf and return that as an error when present.

Update the sample client to output status details when printing a gRPC
error.

Update the unary echo service jsonnet method definition to return a
status instead of a response when the message is "Bart", and include a
sample `details` field.

Update the README to document the status result of a method.