### PR TITLE
Add metadata handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: build test check-coverage lint lint-protos ## build, test, check coverage a
 
 ci: clean check-uptodate all  ## Full clean build and up-to-date checks as run on CI
 
-check-uptodate: protos pb
+check-uptodate: protos pb tidy
 	test -z "$$(git status --porcelain)"
 
 clean::  ## Remove generated files
@@ -30,7 +30,10 @@ build: | $(O)  ## Build reflect binaries
 install:  ## Build and install binaries in $GOBIN
 	go install -ldflags='$(GO_LDFLAGS)' $(CMDS)
 
-.PHONY: build install
+tidy:  ## Tidy go modules with "go mod tidy"
+	go mod tidy
+
+.PHONY: build install tidy
 
 # --- Test ---------------------------------------------------------------------
 COVERFILE = $(O)/coverage.txt

--- a/go.mod
+++ b/go.mod
@@ -5,20 +5,16 @@ go 1.17
 require (
 	github.com/alecthomas/kong v0.2.19
 	github.com/google/go-jsonnet v0.17.0
-	github.com/stretchr/testify v1.7.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,8 @@ github.com/google/go-jsonnet v0.17.0 h1:/9NIEfhK1NQRKl3sP2536b2+x5HnZMdql7x3yK/l
 github.com/google/go-jsonnet v0.17.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -155,7 +153,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -132,7 +132,7 @@ func runBiDiStream(client echo.EchoServiceClient, cfg *config) error {
 }
 
 func statusWithDetails(err error) error {
-	if st, ok := status.FromError(err); ok {
+	if st, ok := status.FromError(err); ok && st != nil {
 		return detailStatusErr{st}
 	}
 	return err

--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -124,7 +124,7 @@ func runBiDiStream(client echo.EchoServiceClient, cfg *config) error {
 		resp, err := stream.Recv()
 		if err != nil {
 			// EOF is an error here, because we expect a response
-			return nil
+			return err
 		}
 		fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
 	}

--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -10,7 +10,9 @@ import (
 
 	"foxygo.at/jig/pb/echo"
 	"github.com/alecthomas/kong"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -56,11 +58,14 @@ func runUnary(client echo.EchoServiceClient, cfg *config) error {
 	if len(cfg.Messages) > 1 {
 		return errors.New("Only one message allowed for unary client requests")
 	}
-	resp, err := client.Hello(context.Background(), &echo.HelloRequest{Message: cfg.Messages[0]})
-	if err != nil {
-		return err
+	var header, trailer metadata.MD
+	req := &echo.HelloRequest{Message: cfg.Messages[0]}
+	resp, err := client.Hello(context.Background(), req, grpc.Header(&header), grpc.Trailer(&trailer))
+	fmt.Fprintf(cfg.out, "Header: %v\n", header)
+	if err == nil {
+		_, err = fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
 	}
-	_, err = fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
+	fmt.Fprintf(cfg.out, "Trailer: %v\n", trailer)
 	return err
 }
 
@@ -74,9 +79,16 @@ func runClientStream(client echo.EchoServiceClient, cfg *config) error {
 			return err
 		}
 	}
-	resp, err := stream.CloseAndRecv()
+	resp, rerr := stream.CloseAndRecv()
+	header, err := stream.Header()
 	if err != nil {
 		return err
+	}
+	fmt.Fprintf(cfg.out, "Header: %v\n", header)
+	defer fmt.Fprintf(cfg.out, "Trailer: %v\n", stream.Trailer())
+
+	if rerr != nil {
+		return rerr
 	}
 	_, err = fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
 	return err
@@ -91,6 +103,14 @@ func runServerStream(client echo.EchoServiceClient, cfg *config) error {
 	if err != nil {
 		return err
 	}
+
+	header, err := stream.Header()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cfg.out, "Header: %v\n", header)
+	defer fmt.Fprintf(cfg.out, "Trailer: %v\n", stream.Trailer())
+
 	for {
 		resp, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -108,27 +128,43 @@ func runServerStream(client echo.EchoServiceClient, cfg *config) error {
 }
 
 func runBiDiStream(client echo.EchoServiceClient, cfg *config) error {
-	stream, err := client.HelloBiDiStream(context.Background())
+	errgrp, ctx := errgroup.WithContext(context.Background())
+
+	stream, err := client.HelloBiDiStream(ctx)
 	if err != nil {
 		return err
 	}
-	for _, msg := range cfg.Messages {
-		if err := stream.Send(&echo.HelloRequest{Message: msg}); err != nil {
-			return err
+
+	// concurrently run each direction of the stream.
+	errgrp.Go(func() error {
+		for _, msg := range cfg.Messages {
+			req := &echo.HelloRequest{Message: msg}
+			if err := stream.Send(req); err != nil {
+				return err
+			}
 		}
-		// We don't need to run stream.Recv() in a separate goroutine like
-		// some bidi methods need as the echo service is synchronous. We
-		// send one request, we get one response. For asynchronous bidi
-		// streaming methods, this Recv() would likely need to be done
-		// concurrently/asynchronously with the Send().
-		resp, err := stream.Recv()
+		return stream.CloseSend()
+	})
+	errgrp.Go(func() error {
+		header, err := stream.Header()
 		if err != nil {
-			// EOF is an error here, because we expect a response
 			return err
 		}
-		fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
-	}
-	return nil
+		fmt.Fprintf(cfg.out, "Header: %v\n", header)
+		defer fmt.Fprintf(cfg.out, "Trailer: %v\n", stream.Trailer())
+		for {
+			resp, err := stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cfg.out, "Response: %s\n", resp.Response)
+		}
+	})
+
+	return errgrp.Wait()
 }
 
 func statusWithDetails(err error) error {

--- a/serve/method.go
+++ b/serve/method.go
@@ -65,7 +65,7 @@ func (m method) streamingClientCall(ss serverStream) error {
 	for {
 		msg := dynamicpb.NewMessage(m.desc.Input())
 		if err := ss.RecvMsg(msg); err != nil {
-			if errors.Is(err, io.EOF) {
+			if !errors.Is(err, io.EOF) {
 				return err
 			}
 			break

--- a/serve/method.go
+++ b/serve/method.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-jsonnet"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -43,12 +44,13 @@ func (m method) call(ss grpc.ServerStream) error {
 
 func (m method) unaryClientCall(ss grpc.ServerStream) error {
 	// Handle unary client (request), with either unary or streaming server (response).
+	md, _ := metadata.FromIncomingContext(ss.Context())
 	req := dynamicpb.NewMessage(m.desc.Input())
 	if err := ss.RecvMsg(req); err != nil {
 		return err
 	}
 
-	input, err := makeInputJSON(req)
+	input, err := makeInputJSON(req, md)
 	if err != nil {
 		return err
 	}
@@ -57,6 +59,7 @@ func (m method) unaryClientCall(ss grpc.ServerStream) error {
 }
 
 func (m method) streamingClientCall(ss grpc.ServerStream) error {
+	md, _ := metadata.FromIncomingContext(ss.Context())
 	var stream []*dynamicpb.Message
 	for {
 		msg := dynamicpb.NewMessage(m.desc.Input())
@@ -75,7 +78,7 @@ func (m method) streamingClientCall(ss grpc.ServerStream) error {
 
 		// For bidirectional streaming, we call jsonnet once for each message
 		// on the input stream and stream out the results.
-		input, err := makeInputJSON(msg)
+		input, err := makeInputJSON(msg, md)
 		if err != nil {
 			return err
 		}
@@ -84,16 +87,17 @@ func (m method) streamingClientCall(ss grpc.ServerStream) error {
 		}
 	}
 
-	// For bidirectional streaming, call jsonnet one last time with a null
-	// request so it knows end-of-stream has been reached.
-	input := "{request: null}"
-
-	if !m.desc.IsStreamingServer() {
-		var err error
-		input, err = makeStreamingInputJSON(stream)
-		if err != nil {
-			return err
-		}
+	var input string
+	var err error
+	if m.desc.IsStreamingServer() {
+		// For bidirectional streaming, call jsonnet one last time with a null
+		// request so it knows end-of-stream has been reached.
+		input, err = makeInputJSON(nil, md)
+	} else {
+		input, err = makeStreamingInputJSON(stream, md)
+	}
+	if err != nil {
+		return err
 	}
 
 	return m.evalJsonnet(input, ss)
@@ -108,11 +112,22 @@ func (m method) evalJsonnet(input string, ss grpc.ServerStream) error {
 		return err
 	}
 
-	stream, err := parseOutputJSON(output, m.desc)
+	result, err := parseOutputJSON(output, m.desc)
 	if err != nil {
 		return err
 	}
-	for _, resp := range stream {
+	if len(result.header) > 0 {
+		if err := ss.SetHeader(result.header); err != nil {
+			return err
+		}
+	}
+	if len(result.trailer) > 0 {
+		ss.SetTrailer(result.trailer)
+	}
+	if result.status != nil {
+		return status.ErrorProto(result.status)
+	}
+	for _, resp := range result.stream {
 		if err := ss.SendMsg(resp); err != nil {
 			return err
 		}
@@ -121,23 +136,36 @@ func (m method) evalJsonnet(input string, ss grpc.ServerStream) error {
 }
 
 type request struct {
+	Header  metadata.MD       `json:"header"`
 	Request json.RawMessage   `json:"request,omitempty"`
 	Stream  []json.RawMessage `json:"stream,omitempty"`
 }
 
 type response struct {
+	Header   metadata.MD       `json:"header"`
+	Trailer  metadata.MD       `json:"trailer"`
 	Response json.RawMessage   `json:"response"`
 	Stream   []json.RawMessage `json:"stream"`
 	Status   json.RawMessage   `json:"status"`
 }
 
-func makeInputJSON(msg *dynamicpb.Message) (string, error) {
-	mo := protojson.MarshalOptions{EmitUnpopulated: true}
-	b, err := mo.Marshal(msg)
-	if err != nil {
-		return "", err
+type methodResult struct {
+	header  metadata.MD
+	trailer metadata.MD
+	stream  []*dynamicpb.Message
+	status  *statuspb.Status
+}
+
+func makeInputJSON(msg *dynamicpb.Message, md metadata.MD) (string, error) {
+	v := request{Header: md, Request: []byte("null")}
+	if msg != nil {
+		mo := protojson.MarshalOptions{EmitUnpopulated: true}
+		b, err := mo.Marshal(msg)
+		if err != nil {
+			return "", err
+		}
+		v.Request = b
 	}
-	v := request{Request: b}
 	input, err := json.Marshal(&v)
 	if err != nil {
 		return "", err
@@ -146,9 +174,9 @@ func makeInputJSON(msg *dynamicpb.Message) (string, error) {
 	return string(input), nil
 }
 
-func makeStreamingInputJSON(stream []*dynamicpb.Message) (string, error) {
+func makeStreamingInputJSON(stream []*dynamicpb.Message, md metadata.MD) (string, error) {
 	mo := protojson.MarshalOptions{EmitUnpopulated: true}
-	v := request{Stream: make([]json.RawMessage, 0, len(stream))}
+	v := request{Header: md, Stream: make([]json.RawMessage, 0, len(stream))}
 	for _, msg := range stream {
 		b, err := mo.Marshal(msg)
 		if err != nil {
@@ -165,10 +193,15 @@ func makeStreamingInputJSON(stream []*dynamicpb.Message) (string, error) {
 	return string(input), nil
 }
 
-func parseOutputJSON(output string, desc protoreflect.MethodDescriptor) ([]*dynamicpb.Message, error) {
+func parseOutputJSON(output string, desc protoreflect.MethodDescriptor) (*methodResult, error) {
 	v := response{}
 	if err := json.Unmarshal([]byte(output), &v); err != nil {
 		return nil, err
+	}
+
+	result := &methodResult{
+		header:  v.Header,
+		trailer: v.Trailer,
 	}
 
 	if len(v.Status) > 0 {
@@ -179,7 +212,8 @@ func parseOutputJSON(output string, desc protoreflect.MethodDescriptor) ([]*dyna
 		if err := protojson.Unmarshal(v.Status, &s); err != nil {
 			return nil, err
 		}
-		return nil, status.ErrorProto(&s)
+		result.status = &s
+		return result, nil
 	}
 
 	// Validate result. A streaming server can return a nil slice.
@@ -197,13 +231,13 @@ func parseOutputJSON(output string, desc protoreflect.MethodDescriptor) ([]*dyna
 		v.Stream = append(v.Stream, v.Response)
 	}
 
-	stream := make([]*dynamicpb.Message, 0, len(v.Stream))
+	result.stream = make([]*dynamicpb.Message, 0, len(v.Stream))
 	for _, jsonMsg := range v.Stream {
 		msg := dynamicpb.NewMessage(desc.Output())
 		if err := protojson.Unmarshal(jsonMsg, msg); err != nil {
 			return nil, err
 		}
-		stream = append(stream, msg)
+		result.stream = append(result.stream, msg)
 	}
-	return stream, nil
+	return result, nil
 }

--- a/testdata/echo.EchoService.Hello.jsonnet
+++ b/testdata/echo.EchoService.Hello.jsonnet
@@ -1,18 +1,27 @@
 function(input)
-  local isBart = input.request.message == 'Bart';
-  {
-    [if !isBart then 'response']: {
-      response: 'Hello ' + input.request.message,
-    },
-
-    [if isBart then 'status']: {
-      code: 3,
-      message: 'eat my shorts',
-      details: [
-        {
-          '@type': 'type.googleapis.com/google.protobuf.Duration',
-          value: '101.212s',
-        },
-      ],
-    },
-  }
+  if input.request.message == 'Bart' then
+    {
+      header: {
+        eat: ['my', 'shorts'],
+      },
+      trailer: {
+        dont: ['have'],
+        a: ['cow'],
+      },
+      status: {
+        code: 3,
+        message: 'eat my shorts',
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.protobuf.Duration',
+            value: '101.212s',
+          },
+        ],
+      },
+    }
+  else
+    {
+      response: {
+        response: 'Hello ' + input.request.message,
+      },
+    }

--- a/testdata/echo.EchoService.HelloBiDiStream.jsonnet
+++ b/testdata/echo.EchoService.HelloBiDiStream.jsonnet
@@ -1,8 +1,22 @@
-function(input) {
-  local response =
-    if input.request == null then
-      []
-    else
-      [{ response: 'Hello ' + input.request.message }],
-  stream: response,
-}
+function(input)
+  if input.request != null && input.request.message == 'Bart' then
+    {
+      status: {
+        code: 3,
+        message: 'eat my shorts',
+      },
+      // Without this header, the content-type is sent in the trailer
+      // as there is nothing in the body. This is a "trailer-only" response.
+      header: {
+        eat: ['his', 'shorts'],
+      },
+    }
+  else
+    {
+      local response =
+        if input.request == null then
+          []
+        else
+          [{ response: 'Hello ' + input.request.message }],
+      stream: response,
+    }

--- a/testdata/echo.EchoService.HelloClientStream.jsonnet
+++ b/testdata/echo.EchoService.HelloClientStream.jsonnet
@@ -3,4 +3,10 @@ function(input) {
     local messages = [req.message for req in input.stream],
     response: 'Hello ' + std.join(' and ', messages),
   },
+  header: {
+    count: [std.toString(std.length(input.stream))],
+  },
+  trailer: {
+    size: [std.toString(std.length($.response.response))],
+  },
 }


### PR DESCRIPTION
Pass the header metadata received from the client to the jsonnet method
and accept header and trailer metadata in the jsonnet method response.

Update some of the testdata to include metadata, sometimes conditional and
with error statuses to ensure that headers and trailers are still sent with
status responses.

Extend the sample client to output the header and trailer metadata (as well
as fix the bidi function to run the streams concurrently).

While we're here, fix some little buglets that crept in.