### PR TITLE
Stop handling EOF explicitly for bidi

### DIFF
--- a/testdata/greet.Greeter.HelloBidiStream.jsonnet
+++ b/testdata/greet.Greeter.HelloBidiStream.jsonnet
@@ -1,5 +1,9 @@
 function(input)
-  if input.request != null && input.request.firstName == 'Bart' then
+  if input.request.firstName != 'Bart' then
+    {
+      stream: [{ greeting: '💃 jig [bidi]: Hello ' + input.request.firstName }],
+    }
+  else // input.request.firstName == 'Bart' then
     {
       status: {
         code: 3,  // InvalidArgument
@@ -10,13 +14,4 @@ function(input)
       header: {
         eat: ['his', 'shorts'],
       },
-    }
-  else
-    {
-      local response =
-        if input.request == null then
-          []
-        else
-          [{ greeting: '💃 jig [bidi]: Hello ' + input.request.firstName }],
-      stream: response,
     }


### PR DESCRIPTION
Stop handling EOF explicitly for bidi streaming as it adds a lot of noise
to the .jsonnet files.

We will worry about EOF handling and possibly exposing it via config when
we need it.