### PR TITLE
Add grpc server reflection

### DIFF
--- a/internal/cmd/server/main.go
+++ b/internal/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"foxygo.at/jig/pb/greet"
 	"github.com/alecthomas/kong"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 var version = "v0.0.0"
@@ -30,6 +31,7 @@ func run(addr string) error {
 		return err
 	}
 	grpcServer := grpc.NewServer()
+	reflection.Register(grpcServer)
 	greet.RegisterGreeterServer(grpcServer, newServer())
 	return grpcServer.Serve(lis)
 }

--- a/reflection/service.go
+++ b/reflection/service.go
@@ -1,0 +1,201 @@
+package reflection
+
+import (
+	"io"
+
+	"foxygo.at/jig/registry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	pb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Service is an implementation of the gRPC ServerReflection service, using a
+// protoregistry.Files as the source of data for serving the reflection
+// methods. No global protobuf/grpc state is consulted for serving.
+type Service struct {
+	registry *registry.Files
+}
+
+// NewService returns a new Service that implements the gRPC ServerReflection
+// service from the given files registry.
+func NewService(files *protoregistry.Files) *Service {
+	r := registry.NewFiles(cloneFiles(files))
+	// Ignore the RegisterFile error on the assumption it means the reflection
+	// protofile is already registered.
+	_ = r.RegisterFile(pb.File_reflection_grpc_reflection_v1alpha_reflection_proto)
+	return &Service{registry: r}
+}
+
+// Register the s Service with the gs grpc ServiceRegistrar. This is a convenience
+// function so the caller does not need to import the grpc_reflection_v1alpha1
+// package.
+func (s *Service) Register(gs grpc.ServiceRegistrar) {
+	pb.RegisterServerReflectionServer(gs, s)
+}
+
+type streamHandler struct {
+	registry *registry.Files
+	seenFDs  map[string]bool
+}
+
+// ServerReflectionInfo implements pb.ServerReflectionServer
+func (s *Service) ServerReflectionInfo(stream pb.ServerReflection_ServerReflectionInfoServer) error {
+	sh := streamHandler{
+		registry: s.registry,
+		seenFDs:  make(map[string]bool),
+	}
+	return sh.handle(stream)
+}
+
+func (sh *streamHandler) handle(stream pb.ServerReflection_ServerReflectionInfoServer) error {
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		out := &pb.ServerReflectionResponse{
+			ValidHost:       in.Host,
+			OriginalRequest: in,
+		}
+
+		switch req := in.MessageRequest.(type) {
+		case *pb.ServerReflectionRequest_FileByFilename:
+			out.MessageResponse, err = sh.fileByFilename(req)
+		case *pb.ServerReflectionRequest_FileContainingSymbol:
+			out.MessageResponse, err = sh.fileContainingSymbol(req)
+		case *pb.ServerReflectionRequest_FileContainingExtension:
+			out.MessageResponse, err = sh.fileContainingExtension(req)
+		case *pb.ServerReflectionRequest_AllExtensionNumbersOfType:
+			out.MessageResponse = sh.allExtensionNumbersOfType(req)
+		case *pb.ServerReflectionRequest_ListServices:
+			out.MessageResponse = sh.listServices(req)
+		}
+
+		if err != nil {
+			out.MessageResponse = &pb.ServerReflectionResponse_ErrorResponse{
+				ErrorResponse: &pb.ErrorResponse{
+					ErrorCode:    int32(codes.NotFound),
+					ErrorMessage: err.Error(),
+				},
+			}
+		}
+		if err := stream.Send(out); err != nil {
+			return err
+		}
+	}
+}
+
+func (sh *streamHandler) fileByFilename(req *pb.ServerReflectionRequest_FileByFilename) (*pb.ServerReflectionResponse_FileDescriptorResponse, error) {
+	fd, err := sh.registry.FindFileByPath(req.FileByFilename)
+	if err != nil {
+		return nil, err
+	}
+	return fileDescriptorResponse(sh.withDeps(fd))
+}
+
+func (sh *streamHandler) fileContainingSymbol(req *pb.ServerReflectionRequest_FileContainingSymbol) (*pb.ServerReflectionResponse_FileDescriptorResponse, error) {
+	symbol := protoreflect.FullName(req.FileContainingSymbol)
+	desc, err := sh.registry.FindDescriptorByName(symbol)
+	if err != nil {
+		return nil, err
+	}
+	return fileDescriptorResponse(sh.withDeps(desc.ParentFile()))
+}
+
+func (sh *streamHandler) fileContainingExtension(req *pb.ServerReflectionRequest_FileContainingExtension) (*pb.ServerReflectionResponse_FileDescriptorResponse, error) {
+	message := protoreflect.FullName(req.FileContainingExtension.ContainingType)
+	number := protoreflect.FieldNumber(req.FileContainingExtension.ExtensionNumber)
+	et, err := sh.registry.FindExtensionByNumber(message, number)
+	if err != nil {
+		return nil, err
+	}
+	return fileDescriptorResponse(sh.withDeps(et.TypeDescriptor().ParentFile()))
+}
+
+func fileDescriptorResponse(fds []protoreflect.FileDescriptor) (*pb.ServerReflectionResponse_FileDescriptorResponse, error) {
+	bs := make([][]byte, len(fds))
+	var err error
+	for i, fd := range fds {
+		bs[i], err = proto.Marshal(protodesc.ToFileDescriptorProto(fd))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &pb.ServerReflectionResponse_FileDescriptorResponse{
+		FileDescriptorResponse: &pb.FileDescriptorResponse{FileDescriptorProto: bs},
+	}, nil
+}
+
+func (sh *streamHandler) allExtensionNumbersOfType(req *pb.ServerReflectionRequest_AllExtensionNumbersOfType) *pb.ServerReflectionResponse_AllExtensionNumbersResponse {
+	message := protoreflect.FullName(req.AllExtensionNumbersOfType)
+	ets := sh.registry.GetExtensionsOfMessage(message)
+	extNums := make([]int32, len(ets))
+	for i, et := range ets {
+		extNums[i] = int32(et.TypeDescriptor().Number())
+	}
+
+	return &pb.ServerReflectionResponse_AllExtensionNumbersResponse{
+		AllExtensionNumbersResponse: &pb.ExtensionNumberResponse{
+			BaseTypeName:    req.AllExtensionNumbersOfType,
+			ExtensionNumber: extNums,
+		},
+	}
+}
+
+func (sh *streamHandler) listServices(req *pb.ServerReflectionRequest_ListServices) *pb.ServerReflectionResponse_ListServicesResponse {
+	serviceResponses := []*pb.ServiceResponse{}
+	sh.registry.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		sds := fd.Services()
+		for i := 0; i < sds.Len(); i++ {
+			sr := &pb.ServiceResponse{Name: string(sds.Get(i).FullName())}
+			serviceResponses = append(serviceResponses, sr)
+		}
+		return true
+	})
+
+	return &pb.ServerReflectionResponse_ListServicesResponse{
+		ListServicesResponse: &pb.ListServiceResponse{
+			Service: serviceResponses,
+		},
+	}
+}
+
+func cloneFiles(files *protoregistry.Files) *protoregistry.Files {
+	clone := &protoregistry.Files{}
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		if err := clone.RegisterFile(fd); err != nil {
+			panic(err)
+		}
+		return true
+	})
+	return clone
+}
+
+func (sh *streamHandler) withDeps(fd protoreflect.FileDescriptor) []protoreflect.FileDescriptor {
+	fds := withDeps(fd, sh.seenFDs)
+	// Always return the fd requested even if it has been seen before
+	if len(fds) == 0 {
+		fds = append(fds, fd)
+	}
+	return fds
+}
+
+func withDeps(fd protoreflect.FileDescriptor, seen map[string]bool) []protoreflect.FileDescriptor {
+	result := []protoreflect.FileDescriptor{}
+	if !seen[fd.Path()] {
+		result = append(result, fd)
+		seen[fd.Path()] = true
+	}
+	for i := 0; i < fd.Imports().Len(); i++ {
+		result = append(result, withDeps(fd.Imports().Get(i), seen)...)
+	}
+	return result
+}

--- a/registry/files.go
+++ b/registry/files.go
@@ -1,0 +1,109 @@
+// Package registry provides a type on top of protoregistry.Files that can be
+// used as a protoregistry.ExtensionTypeResolver and a
+// protoregistry.MessageTypeResolver. This allows a protoregistry.Files to be
+// used as Resolver for protobuf encoding marshaling options.
+package registry
+
+import (
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type Files struct {
+	protoregistry.Files
+}
+
+func NewFiles(f *protoregistry.Files) *Files {
+	return &Files{Files: *f}
+}
+
+type extMatchFn func(protoreflect.ExtensionDescriptor) bool
+
+func (f *Files) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	return findExtension(&f.Files, func(ed protoreflect.ExtensionDescriptor) bool {
+		return ed.FullName() == field
+	})
+}
+
+func (f *Files) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	return findExtension(&f.Files, func(ed protoreflect.ExtensionDescriptor) bool {
+		return ed.ContainingMessage().FullName() == message && ed.Number() == field
+	})
+}
+
+func (f *Files) GetExtensionsOfMessage(message protoreflect.FullName) []protoreflect.ExtensionType {
+	return walkExtensions(&f.Files, true, func(ed protoreflect.ExtensionDescriptor) bool {
+		return ed.ContainingMessage().FullName() == message
+	})
+}
+
+func findExtension(files *protoregistry.Files, pred extMatchFn) (protoreflect.ExtensionType, error) {
+	ets := walkExtensions(files, false, pred)
+	if len(ets) == 0 {
+		return nil, protoregistry.NotFound
+	}
+	return ets[0], nil
+}
+
+func walkExtensions(files *protoregistry.Files, getAll bool, pred extMatchFn) []protoreflect.ExtensionType {
+	var eds []protoreflect.ExtensionDescriptor
+
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		eds = append(eds, rangeExtensions(fd.Extensions(), getAll, pred)...)
+		if len(eds) > 0 && !getAll {
+			return false // stop after the first found
+		}
+		eds = append(eds, rangeMessages(fd.Messages(), getAll, pred)...)
+		if len(eds) > 0 && !getAll {
+			return false // stop after the first found
+		}
+		return true
+	})
+
+	result := make([]protoreflect.ExtensionType, len(eds))
+	for i, ed := range eds {
+		result[i] = dynamicpb.NewExtensionType(ed)
+	}
+	return result
+}
+
+func rangeExtensions(eds protoreflect.ExtensionDescriptors, getAll bool, pred extMatchFn) []protoreflect.ExtensionDescriptor {
+	var result []protoreflect.ExtensionDescriptor
+
+	for i := 0; i < eds.Len(); i++ {
+		ed := eds.Get(i)
+		if pred(ed) {
+			result = append(result, ed)
+			if !getAll {
+				break
+			}
+		}
+	}
+	return result
+}
+
+func rangeMessages(mds protoreflect.MessageDescriptors, getAll bool, pred extMatchFn) []protoreflect.ExtensionDescriptor {
+	var result []protoreflect.ExtensionDescriptor
+
+	for i := 0; i < mds.Len(); i++ {
+		md := mds.Get(i)
+		result = append(result, rangeExtensions(md.Extensions(), getAll, pred)...)
+		if len(result) > 0 && !getAll {
+			break
+		}
+		result = append(result, rangeMessages(md.Messages(), getAll, pred)...)
+		if len(result) > 0 && !getAll {
+			break
+		}
+	}
+	return result
+}
+
+func (f *Files) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	return nil, protoregistry.NotFound
+}
+
+func (f *Files) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	return nil, protoregistry.NotFound
+}


### PR DESCRIPTION
Add an implementation of the `ServerReflection` gRPC service, reflecting
over the `protoregistry.Files` registry used by the `serve` command.

This re-implements the service instead of using the existing
implementation as the existing implementation reflects over the global
registry which is not populated for our use case.

Add a wrapper for the `protoregistry.Files` type to implement the
`ExensionTypeResolver` and `MessageTypeResolver` so that it can be used
as a resolver for marshaling and unmarshaling text formats. The
`ExtensionTypeResolver` is useful for implementing one of the
ServerReflection requests (FileContainingExtensions).
`MessageTypeResolver` is currently unimplemented (TODO) but will be
implemented for completeness.

Turn on standard server reflection for the sample server so it can
be used as a baseline for comparison with this implementation.

Link: https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto