### PR TITLE
Changer serve.Server to align with http.Server

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,11 +36,10 @@ func main() {
 
 func (cs *cmdServe) Run() error {
 	s := serve.Server{
-		Listen:    cs.Listen,
 		MethodDir: cs.MethodDir,
 		ProtoSet:  cs.ProtoSet,
 	}
-	return s.Run()
+	return s.ListenAndServe(cs.Listen)
 }
 
 func (cb *cmdBones) Run() error {

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -10,13 +10,8 @@ import (
 )
 
 func newTestServer(methodDir string) *TestServer {
-	return &TestServer{
-		Server{
-			Listen:    "localhost:0",
-			MethodDir: (filepath.Join("testdata", methodDir)),
-			ProtoSet:  "testdata/greeter.pb",
-		},
-	}
+	methodDir = filepath.Join("testdata", methodDir)
+	return NewTestServer(methodDir, "testdata/greeter.pb")
 }
 
 type testCase struct {
@@ -26,7 +21,6 @@ type testCase struct {
 
 func TestGreeterSample(t *testing.T) {
 	ts := newTestServer("sample")
-	require.NoError(t, ts.Start())
 	defer ts.Stop()
 
 	c, err := client.New(ts.Addr())
@@ -81,7 +75,6 @@ type testCaseStatus struct {
 
 func TestGreeterSampleStatus(t *testing.T) {
 	ts := newTestServer("sample")
-	require.NoError(t, ts.Start())
 	defer ts.Stop()
 
 	c, err := client.New(ts.Addr())


### PR DESCRIPTION
Changer serve.Server to align with http.Server, implementing a Server
and ListenAndServe method. This makes it also easier to create
TestServer similar to httptest.Server.

This refactor was motivated by the desire to run a _ready_ jigServer in
a go routine as

   jigServer.Run()

or similar and to avoid separate network probing and readiness check.