### PR TITLE
serve: Support for pluggable evaluator

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ func main() {
 
 func (cs *cmdServe) Run() error {
 	withLogger := serve.WithLogger(serve.NewLogger(os.Stderr, cs.LogLevel))
-	withDirs := serve.WithDirs(cs.Dirs...)
-	s, err := serve.NewServer(withDirs, withLogger)
+	dirs := serve.NewFSFromDirs(cs.Dirs...)
+	s, err := serve.NewServer(serve.JsonnetEvaluator(), dirs, withLogger)
 	if err != nil {
 		return err
 	}

--- a/serve/evaluator.go
+++ b/serve/evaluator.go
@@ -1,0 +1,30 @@
+package serve
+
+import (
+	"io/fs"
+
+	"github.com/google/go-jsonnet"
+)
+
+type Evaluator interface {
+	Evaluate(method, input string, vfs fs.FS) (output string, err error)
+}
+
+type EvaluatorFunc func(method, input string, vfs fs.FS) (output string, err error)
+
+func (ef EvaluatorFunc) Evaluate(method, input string, vfs fs.FS) (output string, err error) {
+	return ef(method, input, vfs)
+}
+
+func JsonnetEvaluator() Evaluator {
+	return EvaluatorFunc(func(method, input string, vfs fs.FS) (output string, err error) {
+		vm := jsonnet.MakeVM()
+		vm.TLACode("input", input)
+		filename := method + ".jsonnet"
+		b, err := fs.ReadFile(vfs, filename)
+		if err != nil {
+			return "", err
+		}
+		return vm.EvaluateAnonymousSnippet(filename, string(b))
+	})
+}

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -13,9 +13,8 @@ import (
 )
 
 func newTestServer() *TestServer {
-	lopOpt := WithLogger(NewLogger(io.Discard, LogLevelError))
-	fsOpt := WithFS(os.DirFS("testdata/greet"))
-	return NewTestServer(lopOpt, fsOpt)
+	withLogger := WithLogger(NewLogger(io.Discard, LogLevelError))
+	return NewTestServer(JsonnetEvaluator(), os.DirFS("testdata/greet"), withLogger)
 }
 
 type testCase struct {
@@ -127,7 +126,7 @@ var embedFS embed.FS
 func TestGreeterEmbedFS(t *testing.T) {
 	methodFS, err := fs.Sub(embedFS, "testdata/greet")
 	require.NoError(t, err)
-	ts := NewTestServer(WithFS(methodFS))
+	ts := NewTestServer(JsonnetEvaluator(), methodFS)
 	defer ts.Stop()
 
 	c, err := client.New(ts.Addr())

--- a/serve/stackedfs.go
+++ b/serve/stackedfs.go
@@ -2,8 +2,23 @@ package serve
 
 import (
 	"io/fs"
+	"os"
 	"sort"
 )
+
+// NewFS combines the top level directories of multiple fs.FS.
+func NewFS(vfs ...fs.FS) fs.FS {
+	return stackedFS(vfs)
+}
+
+// NewFSFromDirs combines the top level directories of multiple directories.
+func NewFSFromDirs(dirs ...string) fs.FS {
+	result := make([]fs.FS, len(dirs))
+	for i, dir := range dirs {
+		result[i] = os.DirFS(dir)
+	}
+	return stackedFS(result)
+}
 
 type stackedFS []fs.FS
 


### PR DESCRIPTION
Support for pluggable evaluator, so that we can run jig with other
scripting languages such as JS. Introduce Evaluator interface assuming
we will add methods for scaffolding with "jig bones".

This PR is a continuation of @alecthomas ' RFC: 
https://github.com/foxygoat/jig/pull/25