### PR TITLE
serve: Fix cli handling of protoset files

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,8 +43,9 @@ func main() {
 
 func (cs *cmdServe) Run() error {
 	withLogger := serve.WithLogger(serve.NewLogger(os.Stderr, cs.LogLevel))
+	withProtosets := serve.WithProtosets(cs.ProtoSet...)
 	dirs := serve.NewFSFromDirs(cs.Dirs...)
-	s, err := serve.NewServer(serve.JsonnetEvaluator(), dirs, withLogger)
+	s, err := serve.NewServer(serve.JsonnetEvaluator(), dirs, withLogger, withProtosets)
 	if err != nil {
 		return err
 	}

--- a/serve/server.go
+++ b/serve/server.go
@@ -116,6 +116,7 @@ func (s *Server) loadMethods() error {
 func (s *Server) loadProtosets() error {
 	seen := map[string]bool{}
 	for _, protoset := range s.protosets {
+		s.log.Debugf("loading protoset file: %s", protoset)
 		b, err := os.ReadFile(protoset)
 		if err != nil {
 			return err
@@ -158,6 +159,7 @@ func (s *Server) addFiles(b []byte, seen map[string]bool) error {
 			return true
 		}
 		seen[fd.Path()] = true
+		s.log.Debugf("loading file descriptor %s", fd.Path())
 		err := s.files.RegisterFile(fd)
 		if err != nil {
 			s.log.Errorf("cannot register %q: %v", fd.FullName(), err)


### PR DESCRIPTION
Pass protoset files specified on the command line with `--protoset` to
`serve.Server` as an option (`WithProtosets`). This got missed in a
recent refactor of method dir handling.

Add a couple of debug logs to see protosets being loaded - this is
generally useful as you don't always know you have the protset files
correct - this helps diagnose issues with protoset files.