### PR TITLE
translate status codes to HTTP response codes

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-package serve
+package log
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"foxygo.at/jig/bones"
+	"foxygo.at/jig/log"
 	"foxygo.at/jig/serve"
 	"github.com/alecthomas/kong"
 )
@@ -17,9 +18,9 @@ type config struct {
 }
 
 type cmdServe struct {
-	ProtoSet []string       `short:"p" help:"Protoset .pb files containing service and deps"`
-	LogLevel serve.LogLevel `help:"Server logging level" default:"error"`
-	Listen   string         `short:"l" default:"localhost:8080" help:"TCP listen address"`
+	ProtoSet []string     `short:"p" help:"Protoset .pb files containing service and deps"`
+	LogLevel log.LogLevel `help:"Server logging level" default:"error"`
+	Listen   string       `short:"l" default:"localhost:8080" help:"TCP listen address"`
 
 	Dirs []string `arg:"" help:"Directory containing method definitions and protoset .pb file"`
 }
@@ -42,7 +43,7 @@ func main() {
 }
 
 func (cs *cmdServe) Run() error {
-	withLogger := serve.WithLogger(serve.NewLogger(os.Stderr, cs.LogLevel))
+	withLogger := serve.WithLogger(log.NewLogger(os.Stderr, cs.LogLevel))
 	withProtosets := serve.WithProtosets(cs.ProtoSet...)
 	dirs := serve.NewFSFromDirs(cs.Dirs...)
 	s, err := serve.NewServer(serve.JsonnetEvaluator(), dirs, withLogger, withProtosets)

--- a/serve/httprule/errors.go
+++ b/serve/httprule/errors.go
@@ -1,0 +1,49 @@
+package httprule
+
+import (
+	"google.golang.org/grpc/codes"
+	"net/http"
+)
+
+// HTTPStatusFromCode converts a gRPC error code into the corresponding HTTP response status.
+// See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+func HTTPStatusFromCode(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.Canceled:
+		return http.StatusRequestTimeout
+	case codes.Unknown:
+		return http.StatusInternalServerError
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.AlreadyExists:
+		return http.StatusConflict
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.FailedPrecondition:
+		return http.StatusBadRequest
+	case codes.Aborted:
+		return http.StatusConflict
+	case codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.Unimplemented:
+		return http.StatusNotImplemented
+	case codes.Internal:
+		return http.StatusInternalServerError
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.DataLoss:
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusInternalServerError
+}

--- a/serve/server.go
+++ b/serve/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"foxygo.at/jig/log"
 	"foxygo.at/jig/reflection"
 	"foxygo.at/jig/registry"
 	"foxygo.at/jig/serve/httprule"
@@ -35,7 +36,7 @@ func WithProtosets(protosets ...string) Option {
 	}
 }
 
-func WithLogger(logger Logger) Option {
+func WithLogger(logger log.Logger) Option {
 	return func(s *Server) error {
 		s.log = logger
 		return nil
@@ -43,7 +44,7 @@ func WithLogger(logger Logger) Option {
 }
 
 type Server struct {
-	log       Logger
+	log       log.Logger
 	gs        *grpc.Server
 	http      *httprule.Server
 	files     *registry.Files
@@ -59,7 +60,7 @@ var errUnknownHandler = errors.New("Unknown handler")
 func NewServer(eval Evaluator, vfs fs.FS, options ...Option) (*Server, error) {
 	s := &Server{
 		files: new(registry.Files),
-		log:   NewLogger(os.Stderr, LogLevelError),
+		log:   log.NewLogger(os.Stderr, log.LogLevelError),
 		eval:  eval,
 		fs:    vfs,
 	}

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"foxygo.at/jig/internal/client"
+	"foxygo.at/jig/log"
 	"foxygo.at/jig/pb/greet"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -20,7 +21,7 @@ import (
 )
 
 func newTestServer() *TestServer {
-	withLogger := WithLogger(NewLogger(io.Discard, LogLevelError))
+	withLogger := WithLogger(log.NewLogger(io.Discard, log.LogLevelError))
 	return NewTestServer(JsonnetEvaluator(), os.DirFS("testdata/greet"), withLogger)
 }
 


### PR DESCRIPTION
Handle grpc errors, translating status pb to error responses. As before, only unary requests are supported.