### PR TITLE
serve: Decouple httprule handler from serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Build and start jig on the test data:
 
     . ./bin/activate-hermit
     make install
-    jig serve serve/testdata/greet
+    jig serve --http serve/testdata/greet
 
 in a second terminal call it with:
 
@@ -126,7 +126,7 @@ To see streaming, call it with:
     client --stream=client you me world
     client --stream=bidi you me world
 
-To call over HTTP, call it with:
+The `--http` flag passed to `jig serve` above allows you to make HTTP requests:
 
     curl \
         -H "Content-Type: application/json" \

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"foxygo.at/jig/bones"
 	"foxygo.at/jig/log"
 	"foxygo.at/jig/serve"
+	"foxygo.at/jig/serve/httprule"
 	"github.com/alecthomas/kong"
 )
 
@@ -21,6 +22,7 @@ type cmdServe struct {
 	ProtoSet []string     `short:"p" help:"Protoset .pb files containing service and deps"`
 	LogLevel log.LogLevel `help:"Server logging level" default:"error"`
 	Listen   string       `short:"l" default:"localhost:8080" help:"TCP listen address"`
+	HTTP     bool         `short:"h" help:"Serve on HTTP too, using HttpRule annotations"`
 
 	Dirs []string `arg:"" help:"Directory containing method definitions and protoset .pb file"`
 }
@@ -50,6 +52,12 @@ func (cs *cmdServe) Run() error {
 	if err != nil {
 		return err
 	}
+
+	if cs.HTTP {
+		h := httprule.NewServer(s.Files, s.UnknownHandler)
+		s.SetHTTPHandler(h)
+	}
+
 	return s.ListenAndServe(cs.Listen)
 }
 

--- a/serve/httprule/server_test.go
+++ b/serve/httprule/server_test.go
@@ -1,0 +1,82 @@
+package httprule
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"foxygo.at/jig/log"
+	"foxygo.at/jig/pb/greet"
+	"foxygo.at/jig/serve"
+	"github.com/stretchr/testify/require"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHTTP(t *testing.T) {
+	withLogger := serve.WithLogger(log.NewLogger(io.Discard, log.LogLevelError))
+	ts := serve.NewTestServer(serve.JsonnetEvaluator(), os.DirFS("testdata/greet"), withLogger)
+	defer ts.Stop()
+
+	h := NewServer(ts.Files, ts.UnknownHandler)
+	ts.SetHTTPHandler(h)
+
+	body := `{"first_name": "Stranger"}`
+	url := fmt.Sprintf("http://%s/api/greet/hello", ts.Addr())
+
+	t.Run("accept JSON response", func(t *testing.T) {
+		resp, err := http.Post(url, "application/json; charset=utf-8", strings.NewReader(body))
+		require.NoError(t, err)
+
+		respPb := &greet.HelloResponse{}
+		raw, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NoError(t, protojson.Unmarshal(raw, respPb))
+
+		expected := &greet.HelloResponse{Greeting: "💃 jig [unary]: Hello Stranger"}
+		require.Truef(t, proto.Equal(expected, respPb), "expected: %s, \nactual: %s", expected, respPb)
+	})
+
+	t.Run("accept binary response", func(t *testing.T) {
+		req, err := http.NewRequest("POST", url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/x-protobuf; charset=utf-8")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		respPb := &greet.HelloResponse{}
+		raw, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NoError(t, proto.Unmarshal(raw, respPb))
+
+		expected := &greet.HelloResponse{Greeting: "💃 jig [unary]: Hello Stranger"}
+		require.Truef(t, proto.Equal(expected, respPb), "expected: %s, \nactual: %s", expected, respPb)
+	})
+
+	t.Run("converts error responses to HTTP", func(t *testing.T) {
+		badRequestBody := `{"first_name": "Bart"}`
+		req, err := http.NewRequest("POST", url, strings.NewReader(badRequestBody))
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/json; charset=utf-8")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		respPb := &statuspb.Status{}
+		raw, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NoError(t, protojson.Unmarshal(raw, respPb))
+
+		respPb.Details = nil
+		expected := &statuspb.Status{Code: 3, Message: "💃 jig [unary]: eat my shorts"}
+		require.Truef(t, proto.Equal(expected, respPb), "expected: %s, \nactual: %s", expected, respPb)
+	})
+}

--- a/serve/httprule/testdata
+++ b/serve/httprule/testdata
@@ -1,0 +1,1 @@
+../testdata

--- a/serve/method.go
+++ b/serve/method.go
@@ -34,12 +34,12 @@ func (s *Server) unaryClientCall(md protoreflect.MethodDescriptor, ss grpc.Serve
 		return err
 	}
 
-	input, err := makeInputJSON(req, mdata, s.files)
+	input, err := makeInputJSON(req, mdata, s.Files)
 	if err != nil {
 		return err
 	}
 
-	return s.evaluate(md, input, ss, s.files)
+	return s.evaluate(md, input, ss, s.Files)
 }
 
 func (s *Server) streamingClientCall(md protoreflect.MethodDescriptor, ss grpc.ServerStream) error {
@@ -56,12 +56,12 @@ func (s *Server) streamingClientCall(md protoreflect.MethodDescriptor, ss grpc.S
 		stream = append(stream, msg)
 	}
 
-	input, err := makeStreamingInputJSON(stream, mdata, s.files)
+	input, err := makeStreamingInputJSON(stream, mdata, s.Files)
 	if err != nil {
 		return err
 	}
 
-	return s.evaluate(md, input, ss, s.files)
+	return s.evaluate(md, input, ss, s.Files)
 }
 
 func (s *Server) streamingBidiCall(md protoreflect.MethodDescriptor, ss grpc.ServerStream) error {
@@ -77,11 +77,11 @@ func (s *Server) streamingBidiCall(md protoreflect.MethodDescriptor, ss grpc.Ser
 
 		// For bidirectional streaming, we call evaluator once for each message
 		// on the input stream and stream out the results.
-		input, err := makeInputJSON(msg, mdata, s.files)
+		input, err := makeInputJSON(msg, mdata, s.Files)
 		if err != nil {
 			return err
 		}
-		if err := s.evaluate(md, input, ss, s.files); err != nil {
+		if err := s.evaluate(md, input, ss, s.Files); err != nil {
 			return err
 		}
 	}
@@ -94,7 +94,7 @@ func (s *Server) evaluate(md protoreflect.MethodDescriptor, input string, ss grp
 		return err
 	}
 
-	result, err := parseOutputJSON(output, md, s.files)
+	result, err := parseOutputJSON(output, md, s.Files)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Decouple `httprule.Server` from `serve.Server` to that alternate
implementations or just other `http.Handlers can be plugged into the
server.

This is done by simplifying the handling of unknown methods in the
server, using an unused parameter to the unknown handler to specify the
method name (making outside callers much simpler), exporting the
server's `registry.Files` field and abstracting the `httprule.Server` in
`serve.Server` as an `http.Handler` and making it pluggable.

This is a breaking change to outside users of the server, requiring them
to create the httprule server themselves and plug it in with:

    s := serve.NewServer(...)
    h := httprule.NewServer(s.Files, s.UnknownHandler)
    s.SetHTTPHandler(h)

If the httprule server is not plugged in then the server will not serve
HTTP via the HttpRule annotations.