### PR TITLE
Infer Content-Type and Accept header

### DIFF
--- a/serve/httprule/httprule.go
+++ b/serve/httprule/httprule.go
@@ -69,6 +69,9 @@ func decodeBody(rule *annotations.HttpRule, req *http.Request, target proto.Mess
 	}
 	mediaType := ContentTypeJSON
 	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = req.Header.Get("Accept")
+	}
 	var err error
 	if contentType != "" {
 		mediaType, _, err = mime.ParseMediaType(contentType)

--- a/serve/httprule/server.go
+++ b/serve/httprule/server.go
@@ -191,6 +191,9 @@ func getAcceptType(r *http.Request) (string, error) {
 	mediaType := ContentTypeJSON
 	// TODO: There's a lot more to parsing Accept headers...
 	accept := r.Header.Get("Accept")
+	if accept == "" {
+		accept = r.Header.Get("Content-Type")
+	}
 	if accept != "" && accept != "*/*" {
 		mediaType, _, err = mime.ParseMediaType(accept)
 		if err != nil {

--- a/serve/httprule/server_test.go
+++ b/serve/httprule/server_test.go
@@ -46,6 +46,7 @@ func TestHTTP(t *testing.T) {
 	t.Run("accept binary response", func(t *testing.T) {
 		req, err := http.NewRequest("POST", url, strings.NewReader(body))
 		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		req.Header.Set("Accept", "application/x-protobuf; charset=utf-8")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)


### PR DESCRIPTION
Infer Content-Type and Accept header when not set: If Content-Type is
not set but Accept header is set, set the inferred content type as
fallback to the accept type. If the Accept header is not set but the
Content-Type header is set, infer the accept type from the
Content-Type.

This fix is proposed to more closely mirror CashApp internal custom
proto over HTTP/1.1 implementations.