### PR TITLE
Pass gRPC metadata through to evaluators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Jig lets you use [jsonnet] to implement gRPC methods, e.g.:
 
     // Greeter.Hello
-    function(input) {
+    function(input, metadata) {
       response: {
         greeting: '💃 : Hello ' + input.request.firstName,
       },
@@ -62,7 +62,7 @@ the response to send back to the gRPC client.
 If the method is a unary or client-streaming method, the result must have a
 `response` field that contains the response message encoded as JSON:
 
-    function(input) {
+    function(input, metadata) {
         response: { ...json-encoded gRPC response protobuf... }
     }
 
@@ -70,13 +70,13 @@ If the method is a server- or bidirectional streaming method, the result must
 have a `stream` field that contains an array of response messages encoded as
 JSON:
 
-    function(input) {
+    function(input, metadata) {
         stream: [ {response1}, {response2}, ... ]
     }
 
 A [gRPC status] can be returned in the `status` field:
 
-    function(input) {
+    function(input, metadata) {
         status: {
             code: 3,
             message: 'Field "foo" failed validation: 0 < foo < 10',

--- a/bones/exemplar.go
+++ b/bones/exemplar.go
@@ -82,10 +82,10 @@ func (f *formatter) MethodExemplar(md protoreflect.MethodDescriptor) exemplar {
 		ome.prepend("response: ")
 	}
 	if f.opts.Lang == Jsonnet {
-		ome.nest("function(input) {", "}")
+		ome.nest("function(input, metadata) {", "}")
 	} else {
 		ome.nest("return {", "}")
-		ome.nest("function "+string(md.Name())+"(input) {", "}")
+		ome.nest("function "+string(md.Name())+"(input, metadata) {", "}")
 	}
 
 	var methodType string

--- a/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.Sample.js
+++ b/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.Sample.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function Sample(input) {
+function Sample(input, metadata) {
   return {
     response: {  // SampleResponse
       aBool: false,  // bool

--- a/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.Sample.jsonnet
+++ b/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.Sample.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // SampleResponse
     aBool: false,  // bool
     aInt32: 0,  // int32

--- a/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.WellKnown.js
+++ b/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.WellKnown.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function WellKnown(input) {
+function WellKnown(input, metadata) {
   return {
     response: {  // WellKnownSample
       any: {  // Any

--- a/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.WellKnown.jsonnet
+++ b/bones/testdata/golden/exemplar-double-no-minimal/exemplar.Exemplar.WellKnown.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // WellKnownSample
     any: {  // Any
       "@type": "type.googleapis.com/google.protobuf.Duration",

--- a/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.Sample.js
+++ b/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.Sample.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function Sample(input) {
+function Sample(input, metadata) {
   return {
     response: {  // exemplar.SampleResponse
     },

--- a/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.Sample.jsonnet
+++ b/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.Sample.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // exemplar.SampleResponse
   },
 }

--- a/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.WellKnown.js
+++ b/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.WellKnown.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function WellKnown(input) {
+function WellKnown(input, metadata) {
   return {
     response: {  // exemplar.WellKnownSample
     },

--- a/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.WellKnown.jsonnet
+++ b/bones/testdata/golden/exemplar-double-yes-minimal/exemplar.Exemplar.WellKnown.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // exemplar.WellKnownSample
   },
 }

--- a/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.Sample.js
+++ b/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.Sample.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function Sample(input) {
+function Sample(input, metadata) {
   return {
     response: {  // SampleResponse
       aBool: false,  // bool

--- a/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.Sample.jsonnet
+++ b/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.Sample.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // SampleResponse
     aBool: false,  // bool
     aInt32: 0,  // int32

--- a/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.WellKnown.js
+++ b/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.WellKnown.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function WellKnown(input) {
+function WellKnown(input, metadata) {
   return {
     response: {  // WellKnownSample
       any: {  // Any

--- a/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.WellKnown.jsonnet
+++ b/bones/testdata/golden/exemplar-single-no-minimal/exemplar.Exemplar.WellKnown.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // WellKnownSample
     any: {  // Any
       '@type': 'type.googleapis.com/google.protobuf.Duration',

--- a/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.Sample.js
+++ b/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.Sample.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function Sample(input) {
+function Sample(input, metadata) {
   return {
     response: {  // exemplar.SampleResponse
     },

--- a/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.Sample.jsonnet
+++ b/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.Sample.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // exemplar.SampleResponse
   },
 }

--- a/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.WellKnown.js
+++ b/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.WellKnown.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function WellKnown(input) {
+function WellKnown(input, metadata) {
   return {
     response: {  // exemplar.WellKnownSample
     },

--- a/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.WellKnown.jsonnet
+++ b/bones/testdata/golden/exemplar-single-yes-minimal/exemplar.Exemplar.WellKnown.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // exemplar.WellKnownSample
   },
 }

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.Hello.js
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.Hello.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function Hello(input) {
+function Hello(input, metadata) {
   return {
     response: {  // HelloResponse
       greeting: "",  // string

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.Hello.jsonnet
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.Hello.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // HelloResponse
     greeting: "",  // string
   },

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloBidiStream.js
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloBidiStream.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function HelloBidiStream(input) {
+function HelloBidiStream(input, metadata) {
   return {
     stream: [
       {  // HelloResponse

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloBidiStream.jsonnet
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloBidiStream.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // HelloResponse
       greeting: "",  // string

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloClientStream.js
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloClientStream.js
@@ -9,7 +9,7 @@
 //   ],
 // }
 
-function HelloClientStream(input) {
+function HelloClientStream(input, metadata) {
   return {
     response: {  // HelloResponse
       greeting: "",  // string

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloClientStream.jsonnet
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloClientStream.jsonnet
@@ -9,7 +9,7 @@
 //   ],
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // HelloResponse
     greeting: "",  // string
   },

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloServerStream.js
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloServerStream.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function HelloServerStream(input) {
+function HelloServerStream(input, metadata) {
   return {
     stream: [
       {  // HelloResponse

--- a/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloServerStream.jsonnet
+++ b/bones/testdata/golden/greet-double-no-minimal/greet.Greeter.HelloServerStream.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // HelloResponse
       greeting: "",  // string

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.Hello.js
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.Hello.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function Hello(input) {
+function Hello(input, metadata) {
   return {
     response: {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.Hello.jsonnet
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.Hello.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // greet.HelloResponse
   },
 }

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloBidiStream.js
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloBidiStream.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function HelloBidiStream(input) {
+function HelloBidiStream(input, metadata) {
   return {
     stream: [
       {  // greet.HelloResponse

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloBidiStream.jsonnet
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloBidiStream.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloClientStream.js
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloClientStream.js
@@ -8,7 +8,7 @@
 //   ],
 // }
 
-function HelloClientStream(input) {
+function HelloClientStream(input, metadata) {
   return {
     response: {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloClientStream.jsonnet
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloClientStream.jsonnet
@@ -8,7 +8,7 @@
 //   ],
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // greet.HelloResponse
   },
 }

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloServerStream.js
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloServerStream.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function HelloServerStream(input) {
+function HelloServerStream(input, metadata) {
   return {
     stream: [
       {  // greet.HelloResponse

--- a/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloServerStream.jsonnet
+++ b/bones/testdata/golden/greet-double-yes-minimal/greet.Greeter.HelloServerStream.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.Hello.js
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.Hello.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function Hello(input) {
+function Hello(input, metadata) {
   return {
     response: {  // HelloResponse
       greeting: '',  // string

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.Hello.jsonnet
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.Hello.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // HelloResponse
     greeting: '',  // string
   },

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloBidiStream.js
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloBidiStream.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function HelloBidiStream(input) {
+function HelloBidiStream(input, metadata) {
   return {
     stream: [
       {  // HelloResponse

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloBidiStream.jsonnet
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloBidiStream.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // HelloResponse
       greeting: '',  // string

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloClientStream.js
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloClientStream.js
@@ -9,7 +9,7 @@
 //   ],
 // }
 
-function HelloClientStream(input) {
+function HelloClientStream(input, metadata) {
   return {
     response: {  // HelloResponse
       greeting: '',  // string

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloClientStream.jsonnet
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloClientStream.jsonnet
@@ -9,7 +9,7 @@
 //   ],
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // HelloResponse
     greeting: '',  // string
   },

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloServerStream.js
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloServerStream.js
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function HelloServerStream(input) {
+function HelloServerStream(input, metadata) {
   return {
     stream: [
       {  // HelloResponse

--- a/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloServerStream.jsonnet
+++ b/bones/testdata/golden/greet-single-no-minimal/greet.Greeter.HelloServerStream.jsonnet
@@ -7,7 +7,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // HelloResponse
       greeting: '',  // string

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.Hello.js
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.Hello.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function Hello(input) {
+function Hello(input, metadata) {
   return {
     response: {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.Hello.jsonnet
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.Hello.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // greet.HelloResponse
   },
 }

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloBidiStream.js
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloBidiStream.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function HelloBidiStream(input) {
+function HelloBidiStream(input, metadata) {
   return {
     stream: [
       {  // greet.HelloResponse

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloBidiStream.jsonnet
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloBidiStream.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloClientStream.js
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloClientStream.js
@@ -8,7 +8,7 @@
 //   ],
 // }
 
-function HelloClientStream(input) {
+function HelloClientStream(input, metadata) {
   return {
     response: {  // greet.HelloResponse
     },

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloClientStream.jsonnet
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloClientStream.jsonnet
@@ -8,7 +8,7 @@
 //   ],
 // }
 
-function(input) {
+function(input, metadata) {
   response: {  // greet.HelloResponse
   },
 }

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloServerStream.js
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloServerStream.js
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function HelloServerStream(input) {
+function HelloServerStream(input, metadata) {
   return {
     stream: [
       {  // greet.HelloResponse

--- a/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloServerStream.jsonnet
+++ b/bones/testdata/golden/greet-single-yes-minimal/greet.Greeter.HelloServerStream.jsonnet
@@ -6,7 +6,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   stream: [
     {  // greet.HelloResponse
     },

--- a/serve/method.go
+++ b/serve/method.go
@@ -39,7 +39,7 @@ func (s *Server) unaryClientCall(md protoreflect.MethodDescriptor, ss grpc.Serve
 		return err
 	}
 
-	return s.evaluate(md, input, ss, s.Files)
+	return s.evaluate(mdata, md, input, ss, s.Files)
 }
 
 func (s *Server) streamingClientCall(md protoreflect.MethodDescriptor, ss grpc.ServerStream) error {
@@ -61,7 +61,7 @@ func (s *Server) streamingClientCall(md protoreflect.MethodDescriptor, ss grpc.S
 		return err
 	}
 
-	return s.evaluate(md, input, ss, s.Files)
+	return s.evaluate(mdata, md, input, ss, s.Files)
 }
 
 func (s *Server) streamingBidiCall(md protoreflect.MethodDescriptor, ss grpc.ServerStream) error {
@@ -81,15 +81,19 @@ func (s *Server) streamingBidiCall(md protoreflect.MethodDescriptor, ss grpc.Ser
 		if err != nil {
 			return err
 		}
-		if err := s.evaluate(md, input, ss, s.Files); err != nil {
+		if err := s.evaluate(mdata, md, input, ss, s.Files); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Server) evaluate(md protoreflect.MethodDescriptor, input string, ss grpc.ServerStream, reg *registry.Files) error {
-	output, err := s.eval.Evaluate(string(md.FullName()), input, s.fs)
+func (s *Server) evaluate(mdata metadata.MD, md protoreflect.MethodDescriptor, input string, ss grpc.ServerStream, reg *registry.Files) error {
+	output, err := s.eval.Evaluate(Request{
+		Metadata: mdata,
+		Method:   string(md.FullName()),
+		Input:    input,
+	}, s.fs)
 	if err != nil {
 		return err
 	}

--- a/serve/testdata/greet/greet.Greeter.Hello.jsonnet
+++ b/serve/testdata/greet/greet.Greeter.Hello.jsonnet
@@ -1,4 +1,4 @@
-function(input)
+function(input, metadata)
   if input.request.firstName == 'Bart' then
     {
       header: {

--- a/serve/testdata/greet/greet.Greeter.HelloBidiStream.jsonnet
+++ b/serve/testdata/greet/greet.Greeter.HelloBidiStream.jsonnet
@@ -1,4 +1,4 @@
-function(input)
+function(input, metadata)
   if input.request.firstName != 'Bart' then
     {
       stream: [{ greeting: '💃 jig [bidi]: Hello ' + input.request.firstName }],

--- a/serve/testdata/greet/greet.Greeter.HelloClientStream.jsonnet
+++ b/serve/testdata/greet/greet.Greeter.HelloClientStream.jsonnet
@@ -1,4 +1,4 @@
-function(input) {
+function(input, metadata) {
   response: {
     local names = [req.firstName for req in input.stream],
     greeting: '💃 jig [client]: Hello ' + std.join(' and ', names),

--- a/serve/testdata/greet/greet.Greeter.HelloServerStream.jsonnet
+++ b/serve/testdata/greet/greet.Greeter.HelloServerStream.jsonnet
@@ -1,4 +1,4 @@
-function(input) {
+function(input, metadata) {
   stream: [
     { greeting: '💃 jig [server]: Hello ' + input.request.firstName },
     { greeting: '💃 jig [server]: Goodbye ' + input.request.firstName },

--- a/serve/testdata/httpgreet/httpgreet.HttpGreeter.GetHello.jsonnet
+++ b/serve/testdata/httpgreet/httpgreet.HttpGreeter.GetHello.jsonnet
@@ -8,7 +8,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {
     greeting: "httpgreet: Hello, " + input.request.firstName,  // string
   },

--- a/serve/testdata/httpgreet/httpgreet.HttpGreeter.PostHello.jsonnet
+++ b/serve/testdata/httpgreet/httpgreet.HttpGreeter.PostHello.jsonnet
@@ -8,7 +8,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {
     greeting: "Thanks for the post, " + input.request.firstName,  // string
   },

--- a/serve/testdata/httpgreet/httpgreet.HttpGreeter.PostHelloURL.jsonnet
+++ b/serve/testdata/httpgreet/httpgreet.HttpGreeter.PostHelloURL.jsonnet
@@ -8,7 +8,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {
     greeting: "Thanks for the post and the path, " + input.request.firstName,  // string
   },

--- a/serve/testdata/httpgreet/httpgreet.HttpGreeter.SimpleHello.jsonnet
+++ b/serve/testdata/httpgreet/httpgreet.HttpGreeter.SimpleHello.jsonnet
@@ -8,7 +8,7 @@
 //   },
 // }
 
-function(input) {
+function(input, metadata) {
   response: {
     greeting: "Simply, hello, " + input.request.firstName,  // string
   },


### PR DESCRIPTION
I considered passing through a struct to the evaluators rather than two
parameters, but decided against it as existing JS evaluators would be
signature-compatible, but data-incompatible, leading to very confusing
failure modes.

As per previous changes, this is backwards incompatible.