### PR TITLE
feat: Parameterize the fallback handler to `httprule.Server`

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -79,7 +80,7 @@ func (cs *cmdServe) Run(logLevel log.LogLevel) error {
 	}
 
 	if cs.HTTP {
-		h := httprule.NewServer(s.Files, s.UnknownHandler, logger, nil)
+		h := httprule.NewServer(s.Files, s.UnknownHandler, logger, nil, http.NotFoundHandler())
 		s.SetHTTPHandler(h)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ func TestHTTPRuleServer(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := serve.NewUnstartedTestServer(serve.JsonnetEvaluator(), os.DirFS("serve/testdata/httpgreet"), opts...)
-	ts.SetHTTPHandler(httprule.NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil))
+	ts.SetHTTPHandler(httprule.NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil, http.NotFoundHandler()))
 	ts.Start()
 	defer ts.Stop()
 

--- a/serve/httprule/server.go
+++ b/serve/httprule/server.go
@@ -29,13 +29,15 @@ type Server struct {
 	httpMethods []*httpMethod
 	grpcHandler grpc.StreamHandler
 	log         log.Logger
+	next        http.Handler
 }
 
-func NewServer(files *registry.Files, handler grpc.StreamHandler, l log.Logger, httpRuleTemplates []*annotations.HttpRule) *Server {
+func NewServer(files *registry.Files, handler grpc.StreamHandler, l log.Logger, httpRuleTemplates []*annotations.HttpRule, next http.Handler) *Server {
 	return &Server{
 		httpMethods: loadHTTPRules(l, files, httpRuleTemplates),
 		grpcHandler: handler,
 		log:         l,
+		next:        next,
 	}
 }
 
@@ -46,7 +48,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	http.NotFound(w, r)
+
+	s.next.ServeHTTP(w, r)
 }
 
 // Serve a google.api.http annotated method as HTTP

--- a/serve/httprule/server_test.go
+++ b/serve/httprule/server_test.go
@@ -24,7 +24,7 @@ func TestHTTP(t *testing.T) {
 	ts := serve.NewTestServer(serve.JsonnetEvaluator(), os.DirFS("testdata/greet"), withLogger)
 	defer ts.Stop()
 
-	h := NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil)
+	h := NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil, http.NotFoundHandler())
 	ts.SetHTTPHandler(h)
 
 	body := `{"first_name": "Stranger"}`
@@ -102,7 +102,7 @@ func TestHTTPRuleInterpolation(t *testing.T) {
 		{Pattern: &annotations.HttpRule_Post{Post: "/post/{package}.{service}/{method}"}, Body: "*"},
 		{Pattern: &annotations.HttpRule_Get{Get: "/get/{method}"}},
 	}
-	h := NewServer(ts.Files, ts.UnknownHandler, logger, tmpl)
+	h := NewServer(ts.Files, ts.UnknownHandler, logger, tmpl, http.NotFoundHandler())
 	ts.SetHTTPHandler(h)
 
 	u := "http://" + ts.Addr() + "/get/SimpleHello"


### PR DESCRIPTION
Allow clients to define their own behavior in place of `http.NotFound` if none of the `httpRuleTemplates` were matched