### PR TITLE
httprule: Add optional "default" handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,10 @@ func (cs *cmdServe) Run(logLevel log.LogLevel) error {
 	}
 
 	if cs.HTTP {
-		h := httprule.NewServer(s.Files, s.UnknownHandler, logger, nil)
+		h, err := httprule.NewHandler(s.Files, s.UnknownHandler, httprule.WithLogger(logger))
+		if err != nil {
+			return err
+		}
 		s.SetHTTPHandler(h)
 	}
 

--- a/serve/httprule/handler.go
+++ b/serve/httprule/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"os"
 	"strings"
 
 	"foxygo.at/jig/log"
@@ -24,25 +25,71 @@ type httpMethod struct {
 	rule *annotations.HttpRule
 }
 
-// Server serves protobuf methods, annotated using httprule options, over HTTP.
-type Server struct {
-	httpMethods []*httpMethod
-	grpcHandler grpc.StreamHandler
-	log         log.Logger
+// Handler serves protobuf methods, annotated using httprule options, over HTTP.
+type Handler struct {
+	httpMethods   []*httpMethod
+	grpcHandler   grpc.StreamHandler
+	log           log.Logger
+	ruleTemplates []*annotations.HttpRule
 }
 
-func NewServer(files *registry.Files, handler grpc.StreamHandler, l log.Logger, httpRuleTemplates []*annotations.HttpRule) *Server {
-	return &Server{
-		httpMethods: loadHTTPRules(l, files, httpRuleTemplates),
-		grpcHandler: handler,
-		log:         l,
+// NewHandler returns a new [Handler] that implements [http.Handler] that will
+// dispatch HTTP requests matching the HttpRule annotations in the given
+// registry. Requests that match a method are dispatched to the given gRPC
+// handler.
+func NewHandler(files *registry.Files, handler grpc.StreamHandler, options ...Option) (*Handler, error) {
+	h := &Handler{grpcHandler: handler}
+	for _, opt := range options {
+		if err := opt(h); err != nil {
+			return nil, err
+		}
+	}
+	if h.log == nil {
+		h.log = log.NewLogger(os.Stderr, log.LogLevelError)
+	}
+	h.httpMethods = loadHTTPRules(h.log, files, h.ruleTemplates)
+
+	return h, nil
+}
+
+// Option is a function option for use with [NewHandler].
+type Option func(h *Handler) error
+
+// WithLogger is an [Option] to configure a [Handler] with the given logger.
+func WithLogger(l log.Logger) Option {
+	return func(h *Handler) error {
+		h.log = l
+		return nil
 	}
 }
 
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	for _, method := range s.httpMethods {
+// WithRuleTemplates is an [Option] to configure a [Handler] to provide a http
+// rule template to be used for gRPC methods that do not have an HttpRule
+// annotation.
+func WithRuleTemplates(httpRuleTemplates []*annotations.HttpRule) Option {
+	return func(h *Handler) error {
+		h.ruleTemplates = httpRuleTemplates
+		return nil
+	}
+}
+
+// Server is a [Handler], and exists for backwards compatibility.
+//
+// Deprecated: Use [Handler] instead.
+type Server = Handler
+
+// NewServer returns a new Handler.
+//
+// Deprecated: Use [NewHandler] instead. [Handler] used to be called [Server].
+func NewServer(files *registry.Files, handler grpc.StreamHandler, l log.Logger, httpRuleTemplates []*annotations.HttpRule) *Handler {
+	h, _ := NewHandler(files, handler, WithLogger(l), WithRuleTemplates(httpRuleTemplates))
+	return h
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, method := range h.httpMethods {
 		if vars := MatchRequest(method.rule, r); vars != nil {
-			s.serveHTTPMethod(method, vars, w, r)
+			h.serveHTTPMethod(method, vars, w, r)
 			return
 		}
 	}
@@ -50,16 +97,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Serve a google.api.http annotated method as HTTP
-func (s *Server) serveHTTPMethod(m *httpMethod, vars map[string]string, w http.ResponseWriter, r *http.Request) {
+func (h *Handler) serveHTTPMethod(m *httpMethod, vars map[string]string, w http.ResponseWriter, r *http.Request) {
 	// TODO: Handle streaming calls.
 	ss := &serverStream{
 		req:        r,
 		respWriter: w,
 		rule:       m.rule,
 		vars:       vars,
-		log:        s.log,
+		log:        h.log,
 	}
-	if err := s.grpcHandler(m.desc.FullName(), ss); err != nil {
+	if err := h.grpcHandler(m.desc.FullName(), ss); err != nil {
 		ss.writeError(err)
 		return
 	}

--- a/serve/httprule/handler_test.go
+++ b/serve/httprule/handler_test.go
@@ -24,7 +24,8 @@ func TestHTTP(t *testing.T) {
 	ts := serve.NewTestServer(serve.JsonnetEvaluator(), os.DirFS("testdata/greet"), withLogger)
 	defer ts.Stop()
 
-	h := NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil)
+	h, err := NewHandler(ts.Files, ts.UnknownHandler, WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
 	ts.SetHTTPHandler(h)
 
 	body := `{"first_name": "Stranger"}`
@@ -102,7 +103,8 @@ func TestHTTPRuleInterpolation(t *testing.T) {
 		{Pattern: &annotations.HttpRule_Post{Post: "/post/{package}.{service}/{method}"}, Body: "*"},
 		{Pattern: &annotations.HttpRule_Get{Get: "/get/{method}"}},
 	}
-	h := NewServer(ts.Files, ts.UnknownHandler, logger, tmpl)
+	h, err := NewHandler(ts.Files, ts.UnknownHandler, WithLogger(logger), WithRuleTemplates(tmpl))
+	require.NoError(t, err)
 	ts.SetHTTPHandler(h)
 
 	u := "http://" + ts.Addr() + "/get/SimpleHello"


### PR DESCRIPTION
Add an optional "default" handler to `httprule.Handler` that is called if 
the request does not match any of the gRPC methods. The default is still to
return a 404 Not Found status if no "default" handler is supplied.

This allows chaining handlers so that other non-gRPC paths can be handled
by other handlers, with precedence given to gRPC paths.

Refactor `httprule.Server` to `httprule.Handler` and add function
options to a new `NewHandler()` constructor. There were already a couple
of optional arguments to `NewServer()` and the "default" handler would
have been another. So switch to function options, leaving the existing
`NewServer()` as is and aliasing `Server` to the new `Handler`.

Co-authored-by: Bob Lail <lail@squareup.com>