### PR TITLE
test: Fix data race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ tidy:  ## Tidy go modules with "go mod tidy"
 COVERFILE = $(O)/coverage.txt
 
 test: | $(O) ## Run tests and generate a coverage file
-	go test -coverprofile=$(COVERFILE) ./...
+	go test -race -coverprofile=$(COVERFILE) ./...
 
 check-coverage: test  ## Check that test coverage meets the required level
 	@go tool cover -func=$(COVERFILE) | $(CHECK_COVERAGE) || $(FAIL_COVERAGE)


### PR DESCRIPTION
Fix data race in go tests detected by Go's race detector. When investigating a
spurious CI failure in the tests, we found that `NewTestServer()` in combination
with test server method `SetHTTPHandler` causes a race as reported by the
detector:

	WARNING: DATA RACE
	Read at 0x00c000354220 by goroutine 10:
	  foxygo.at/jig/serve.(*Server).Serve()
	      /Users/julia/Development/jig/serve/server.go:102 +0x208
	  foxygo.at/jig/serve.(*TestServer).Start.func1()
	      /Users/julia/Development/jig/serve/server.go:269 +0x50

	Previous write at 0x00c000354220 by goroutine 7:
	  foxygo.at/jig/serve.(*Server).SetHTTPHandler()
	      /Users/julia/Development/jig/serve/server.go:96 +0x1ec
	  foxygo.at/jig/serve/httprule.TestHTTP()
	      /Users/julia/Development/jig/serve/httprule/handler_test.go:29 +0x1dc

Fix by using `NewUnstartedTestServer` and explicitly and synchronously calling
`Start` method after calling `SetHTTPHandler`.

Add the `-race` flag in Makefile to Go test execution.