### PR TITLE
housekeeping: Complete previous fixups

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -27,7 +27,9 @@ func TestHTTPRuleServer(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := serve.NewUnstartedTestServer(serve.JsonnetEvaluator(), os.DirFS("serve/testdata/httpgreet"), opts...)
-	ts.SetHTTPHandler(httprule.NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil))
+	handler, err := httprule.NewHandler(ts.Files, ts.UnknownHandler, httprule.WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	ts.SetHTTPHandler(handler)
 	ts.Start()
 	defer ts.Stop()
 
@@ -62,7 +64,9 @@ func TestExemplar(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := serve.NewUnstartedTestServer(serve.JsonnetEvaluator(), os.DirFS("bones/testdata/golden/exemplar-single-no-minimal"), opts...)
-	ts.SetHTTPHandler(httprule.NewServer(ts.Files, ts.UnknownHandler, log.DiscardLogger, nil))
+	handler, err := httprule.NewHandler(ts.Files, ts.UnknownHandler, httprule.WithLogger(log.DiscardLogger))
+	require.NoError(t, err)
+	ts.SetHTTPHandler(handler)
 	ts.Start()
 	defer ts.Stop()
 

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -149,14 +149,14 @@ Trailer: map[]
 }
 
 func TestHTTPHandler(t *testing.T) {
-	ts := newTestServer()
-	defer ts.Stop()
-
+	ts := NewUnstartedTestServer(JsonnetEvaluator(), os.DirFS("testdata/greet"), WithLogger(log.DiscardLogger))
 	mux := http.NewServeMux()
 	mux.HandleFunc("/foo", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("bar")) //nolint:errcheck
 	})
 	ts.SetHTTPHandler(mux)
+	ts.Start()
+	defer ts.Stop()
 
 	c, err := client.New(ts.Addr())
 	require.NoError(t, err)


### PR DESCRIPTION
Complete previous fixups removing deprecated calls to `httprule.NewServer` and
avoiding data races by calling `server.NewUnstartedTestServer`.

---

I AM NOT SORRY
