### PR TITLE
Fix goreleaser flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ GENPROTO_PB_FLAGS = --descriptor_set_out=$(PROTO:proto/%.proto=pb/%.pb) --includ
 release: nexttag  ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 nexttag:
 	$(eval NEXTTAG := $(shell $(NEXTTAG_CMD)))


### PR DESCRIPTION
Fix goreleaser to use `--clean` instead of `-rm-dist`. This should un-break the
build on the master branch which continuously releases.

Link: https://goreleaser.com/deprecations/#-rm-dist